### PR TITLE
fix template so that dockerfile_lint doesn't show errors

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,4 +1,4 @@
-FROM fedora:latest
+FROM fedora:25
 
 # Provide some Dockerfile description, like is mentioned below
 # Volumes:
@@ -17,8 +17,13 @@ RUN dnf install -y --setopt=tsflags=nodocs <your_package_names> && \
 MAINTAINER "real_name" <email_adress>
 
 LABEL summary="Postfix is a Mail Transport Agent (MTA)." \
-       version = "1.0" \
+       name="Postfix 3.1" \
+       version="1.0" \
+       Release="0.1" \
        description="Postfix is mail transfer agent that routes and delivers mail." \
+       vendor="Fedora Project" \
+       Org.fedoraproject.component="postfix" \
+       authoritative-source-url="registry.fedoraproject.org" \
        io.k8s.description="Postfix is mail transfer agent that routes and delivers mail." \
        io.k8s.display-name="Postfix 3.1" \
        io.openshift.expose-services="10025:postfix" \


### PR DESCRIPTION
dockerfile_lint shows these errors:
--------ERRORS---------

Line 1: -> FROM fedora:latest
ERROR: base image uses 'latest' tag. using the 'latest' tag may cause unpredictable builds. It is recommended that a specific tag is used in the FROM line or *-released which is the latest supported release.. 
Reference -> https://docs.docker.com/reference/builder/#from


Line 25: -> LABEL summary="Postfix is a Mail Transport Agent (MTA)."        version = "1.0"        description="Postfix is mail transfer agent that routes and delivers mail."        io.k8s.description="Postfix is mail transfer agent that routes and delivers mail."        io.k8s.display-name="Postfix 3.1"        io.openshift.expose-services="10025:postfix"        io.openshift.tags="postfix,mail,mta"
ERROR: Syntax error - can't find = in version. Must be of the form: name=value. 
Reference -> https://docs.docker.com/reference/builder/


ERROR: Required LABEL name/key 'Org.fedoraproject.component' is not defined. 
Reference -> https://github.com/projectatomic/ContainerApplicationGenericLabels/blob/master/vendor/redhat/labels.md


ERROR: Required LABEL name/key 'Authoritative-source-url' is not defined. 
Reference -> https://github.com/projectatomic/ContainerApplicationGenericLabels/blob/master/vendor/redhat/labels.md


ERROR: Required LABEL name/key 'Version' is not defined. 
Reference -> http://docs.projectatomic.io/container-best-practices/#_recommended_labels_for_your_project


ERROR: Required LABEL name/key 'Release' is not defined. 
Reference -> http://docs.projectatomic.io/container-best-practices/#_recommended_labels_for_your_project


ERROR: Required LABEL name/key 'Vendor' is not defined. 
Reference -> http://docs.projectatomic.io/container-best-practices/#_recommended_labels_for_your_project


